### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/src/extension/mapml/src/main/resources/GeoServerApplication_fr.properties
+++ b/src/extension/mapml/src/main/resources/GeoServerApplication_fr.properties
@@ -5,17 +5,12 @@ format.wms.text/mapml=MapML
 # Well known WFS formats
 format.wfs.MAPML=MapML
 format.wfs.text/mapml=MapML
-
 MapMLPage.page.title=MapML
 MapMLPage.page.description=Service MapML
-
 MapMLPage.title=Service MapML
 MapMLPage.description=Configuration du service MapML
-
 MapMLPreviewLink.title=MapML
-
 MapMLPreviewLink.title=MapML
-
 MapMLLayerConfigurationPanel.mapmlSectionHeading=Paramètres MapML
 MapMLLayerConfigurationPanel.mapmlLicenseSection=Information de licence
 MapMLLayerConfigurationPanel.mapmlLicenseTitle=Titre de la licence
@@ -28,11 +23,10 @@ MapMLLayerConfigurationPanel.mapmlShardList=Liste des shards (séparés par des vi
 MapMLLayerConfigurationPanel.mapmlShardServerPattern=Schéma des serveurs shard (inclure {s} comme remplaçant de shard)
 MapMLLayerConfigurationPanel.mapmlDimensionSection=Configuration des dimensions
 MapMLLayerConfigurationPanel.mapmlDimension=Dimension
-MapMLLayerConfigurationPanel.dimension.nullValid=Aucun
+MapMLLayerConfigurationPanel.dimension.nullValid=Aucun 
 MapMLLayerConfigurationPanel.mapmlFeatureCaptionSection=Correspondance entre attributs et &lt;featurecaption&gt;
 MapMLLayerConfigurationPanel.mapmlFeatureCaption=Liste des attributs
 MapMLLayerConfigurationPanel.mapmlFeatureCaptionTemplate=Texte modèle pour la légende d'une entité (saisir un texte contenant 0 ou plus remplaçants &#36;{attribute-name} à remplacer par les valeurs des attributs dans la légende de l'entité)
-
 MapMLLayerGroupConfigurationPanel.mapmlSectionHeading=Paramètres MapML
 MapMLLayerGroupConfigurationPanel.mapmlLicenseSection=Information de licence
 MapMLLayerGroupConfigurationPanel.mapmlLicenseTitle=Titre de la licence
@@ -42,4 +36,4 @@ MapMLLayerGroupConfigurationPanel.mapmlUseTiles=Utiliser des tuiles
 MapMLLayerGroupConfigurationPanel.mapmlShardSection=Configuration du sharding
 MapMLLayerGroupConfigurationPanel.mapmlEnableSharding=Activer le sharding
 MapMLLayerGroupConfigurationPanel.mapmlShardList=Liste des shards (séparés par des virgules)
-MapMLLayerGroupConfigurationPanel.mapmlShardServerPattern=Schéma des serveurs shard (inclure {s} comme remplaçant de shard)
+MapMLLayerGroupConfigurationPanel.mapmlShardServerPattern=Sch\u00E9ma des serveurs shard (inclure {s} comme rempla\u00E7ant du shard)


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [GeoServer/extension-mapml](https://weblate.osgeo.org/projects/geoserver/extension-mapml/).



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widget/geoserver/extension-mapml/horizontal-auto.svg)